### PR TITLE
Changed behavior in Storage API for config row detail 

### DIFF
--- a/plugin/providers/keboola/resource_keboola_transformation.go
+++ b/plugin/providers/keboola/resource_keboola_transformation.go
@@ -168,7 +168,7 @@ func resourceKeboolaTransformRead(d *schema.ResourceData, meta interface{}) erro
 	log.Println("[INFO] Reading Transformations from Keboola.")
 
 	client := meta.(*KBCClient)
-	getResponse, err := client.GetFromStorage(fmt.Sprintf("storage/components/transformation/configs/%s/rows/%s", d.Get("bucket_id"), d.Id()))
+	getResponse, err := client.GetFromStorage(fmt.Sprintf("storage/components/transformation/configs/%s/rows", d.Get("bucket_id")))
 
 	if hasErrors(err, getResponse) {
 		if getResponse.StatusCode == 404 {


### PR DESCRIPTION
FIXES #44 

This should ensure that release of row detail API resource won't break terraform provisioning.