### PR TITLE
Indexed columns deprecated

### DIFF
--- a/plugin/providers/keboola/resource_keboola_storage_table.go
+++ b/plugin/providers/keboola/resource_keboola_storage_table.go
@@ -185,16 +185,6 @@ func resourceKeboolaStorageTableCreate(d *schema.ResourceData, meta interface{})
 		tableLoadStatus = tableLoadStatusResult.Status
 	}
 
-	indexedOnlyColumns := except(AsStringArray(d.Get("indexed_columns").([]interface{})), AsStringArray(d.Get("primary_key").([]interface{})))
-
-	for _, indexedColumn := range indexedOnlyColumns {
-		addIndexedColumnResp, err := client.PostToStorage(fmt.Sprintf("storage/tables/%s/indexed-columns?name=%s", tableLoadStatusResult.Results.ID, indexedColumn), buffer.Empty())
-
-		if hasErrors(err, addIndexedColumnResp) {
-			return extractError(err, addIndexedColumnResp)
-		}
-	}
-
 	d.SetId(tableLoadStatusResult.Results.ID)
 
 	return resourceKeboolaStorageTableRead(d, meta)


### PR DESCRIPTION
Hi,
there is no longer need for indexing the columns. All colums support same filtering features.
http://status.keboola.com/week-in-review-february-12-2018

We are going to remove deprecated `addIndexedColumns` and `removeIndexed` column resources soon.
thanks