### PR TITLE
Support disabling/enabling Keboola Orchestrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.3 (unreleased)
+
+IMPROVEMENTS:
+
+* Added support for `enabled` on `keboola_orchestration`, which allows control over whether an Orchestration will automatically run on its configured schedule.
+
 ## 0.3.2 (18 July 2019)
 
 FIXES:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-version=0.3.2
+version=0.3.3
 
 default: build deploy
 

--- a/plugin/providers/keboola/resource_keboola_orchestration_test.go
+++ b/plugin/providers/keboola/resource_keboola_orchestration_test.go
@@ -20,6 +20,26 @@ func TestAccOrchestration_Basic(t *testing.T) {
 				Config: testOrchestrationBasic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("keboola_orchestration.test_orchestration", "name", "test name"),
+					resource.TestCheckResourceAttr("keboola_orchestration.test_orchestration", "enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOrchestration_Disabled(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckOrchestrationDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testOrchestrationDisabled,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("keboola_orchestration.test_orchestration", "name", "test name"),
+					resource.TestCheckResourceAttr("keboola_orchestration.test_orchestration", "enabled", "false"),
 				),
 			},
 		},
@@ -49,6 +69,17 @@ func testAccCheckOrchestrationDestroy(s *terraform.State) error {
 const testOrchestrationBasic = `
 resource "keboola_orchestration" "test_orchestration" {
 	name = "test name"
+
+	notification {
+		email   = "hopefullydoesnot.exist@anywhere.cheese"
+		channel = "error"
+	}
+}`
+
+const testOrchestrationDisabled = `
+resource "keboola_orchestration" "test_orchestration" {
+	name    = "test name"
+	enabled = false
 
 	notification {
 		email   = "hopefullydoesnot.exist@anywhere.cheese"


### PR DESCRIPTION
Adds support for `enabled` setting.

Because Keboola ignores the flag when an Orchestration is created (Orchestrations are always enabled when they are made), this requires an additional API call to update the Orchestration.